### PR TITLE
Fixed support for UTF-8 paths on Windows

### DIFF
--- a/pico/lib/picodata.h
+++ b/pico/lib/picodata.h
@@ -83,13 +83,13 @@ void picodata_disposeCharBuffer(picoos_MemoryManager mm,
                                 picodata_CharBuffer * this);
 
 /* should not be used for PUs but only for feeding the initial cb */
-pico_status_t picodata_cbPutCh(register picodata_CharBuffer this, picoos_char ch);
+pico_status_t picodata_cbPutCh(picodata_CharBuffer this, picoos_char ch);
 
 /* should not be used for PUs other than first PU in the chain (picotok) */
-picoos_int16 picodata_cbGetCh(register picodata_CharBuffer this);
+picoos_int16 picodata_cbGetCh(picodata_CharBuffer this);
 
 /* reset cb (as if after newCharBuffer) */
-pico_status_t picodata_cbReset (register picodata_CharBuffer this);
+pico_status_t picodata_cbReset (picodata_CharBuffer this);
 
 /* ** CharBuffer item functions, cf. below in items section ****/
 
@@ -298,7 +298,7 @@ typedef struct picodata_itemhead
      PICO_EXC_BUF_UNDERFLOW  <- cb not empty, but no valid item
      PICO_EXC_BUF_OVERFLOW   <- buf not large enough
 */
-pico_status_t picodata_cbGetItem(register picodata_CharBuffer this,
+pico_status_t picodata_cbGetItem(picodata_CharBuffer this,
         picoos_uint8 *buf, const picoos_uint16 blenmax,
         picoos_uint16 *blen);
 
@@ -310,7 +310,7 @@ pico_status_t picodata_cbGetItem(register picodata_CharBuffer this,
      PICO_EXC_BUF_UNDERFLOW  <- cb not empty, but no valid item
      PICO_EXC_BUF_OVERFLOW   <- buf not large enough
 */
-pico_status_t picodata_cbGetSpeechData(register picodata_CharBuffer this,
+pico_status_t picodata_cbGetSpeechData(picodata_CharBuffer this,
         picoos_uint8 *buf, const picoos_uint16 blenmax,
         picoos_uint16 *blen);
 
@@ -321,12 +321,12 @@ pico_status_t picodata_cbGetSpeechData(register picodata_CharBuffer this,
      PICO_EXC_BUF_UNDERFLOW  <- no valid item in buf
      PICO_EXC_BUF_OVERFLOW   <- cb not large enough
 */
-pico_status_t picodata_cbPutItem(register picodata_CharBuffer this,
+pico_status_t picodata_cbPutItem(picodata_CharBuffer this,
         const picoos_uint8 *buf, const picoos_uint16 blenmax,
         picoos_uint16 *blen);
 
 /* unsafe, just for measuring purposes */
-picoos_uint8 picodata_cbGetFrontItemType(register picodata_CharBuffer this);
+picoos_uint8 picodata_cbGetFrontItemType(picodata_CharBuffer this);
 
 /* ***************************************************************
  *                   items: support function                     *
@@ -498,10 +498,10 @@ pico_status_t picodata_setCbIn(picodata_ProcessingUnit this, picodata_CharBuffer
 pico_status_t picodata_setCbOut(picodata_ProcessingUnit this, picodata_CharBuffer cbOut);
 
 /* protected */
-typedef pico_status_t (* picodata_puInitializeMethod) (register picodata_ProcessingUnit this, picoos_int32 mode);
-typedef pico_status_t (* picodata_puTerminateMethod) (register picodata_ProcessingUnit this);
-typedef picodata_step_result_t (* picodata_puStepMethod) (register picodata_ProcessingUnit this, picoos_int16 mode, picoos_uint16 * numBytesOutput);
-typedef pico_status_t (* picodata_puSubDeallocateMethod) (register picodata_ProcessingUnit this, picoos_MemoryManager mm);
+typedef pico_status_t (* picodata_puInitializeMethod) (picodata_ProcessingUnit this, picoos_int32 mode);
+typedef pico_status_t (* picodata_puTerminateMethod) (picodata_ProcessingUnit this);
+typedef picodata_step_result_t (* picodata_puStepMethod) (picodata_ProcessingUnit this, picoos_int16 mode, picoos_uint16 * numBytesOutput);
+typedef pico_status_t (* picodata_puSubDeallocateMethod) (picodata_ProcessingUnit this, picoos_MemoryManager mm);
 
 typedef struct picodata_processing_unit
 {

--- a/pico/lib/picoknow.h
+++ b/pico/lib/picoknow.h
@@ -164,7 +164,7 @@ typedef enum picoknow_kb_id {
  */
 typedef struct picoknow_knowledge_base * picoknow_KnowledgeBase;
 
-typedef pico_status_t (* picoknow_kbSubDeallocate) (register picoknow_KnowledgeBase this, picoos_MemoryManager mm);
+typedef pico_status_t (* picoknow_kbSubDeallocate) (picoknow_KnowledgeBase this, picoos_MemoryManager mm);
 
 typedef struct picoknow_knowledge_base {
     /* public */

--- a/pico/lib/picopal.c
+++ b/pico/lib/picopal.c
@@ -306,28 +306,52 @@ picopal_char picopal_eol(void)
     If the opening of the file is successful a file pointer is given
     back. Otherwise a NIL-File is given back.
 */
-picopal_File picopal_fopen (picopal_char filename[], picopal_access_mode mode)
-{
-    picopal_File res;
-
-     switch (mode) {
-     case PICOPAL_TEXT_READ :
-         res = (picopal_File) fopen((char *)filename, (char *)"r");
-         break;
-     case PICOPAL_TEXT_WRITE :
-         res = (picopal_File) fopen((char *)filename, (char *)"w");
-         break;
-     case PICOPAL_BINARY_READ :
-         res = (picopal_File) fopen((char *)filename, (char *)"rb");
-         break;
-     case PICOPAL_BINARY_WRITE :
-         res = (picopal_File) fopen((char *)filename, (char *)"wb");
-         break;
-     default :
-         res = (picopal_File) NULL;
-     }
-     return res;
-
+picopal_File picopal_fopen(picopal_char filename[], picopal_access_mode mode) {
+  picopal_File res;
+#ifdef _WIN32
+  wchar_t *m;
+  switch (mode) {
+  case PICOPAL_TEXT_READ:
+    m = L"r";
+    break;
+  case PICOPAL_TEXT_WRITE:
+    m = L"w";
+    break;
+  case PICOPAL_BINARY_READ:
+    m = L"rb";
+    break;
+  case PICOPAL_BINARY_WRITE:
+    m = L"wb";
+    break;
+  default:
+    return (picopal_File)NULL;
+  }
+  const int len = strlen(filename) + 1;
+  wchar_t *wFileName = (wchar_t *)malloc(sizeof(wchar_t) * len);
+  MultiByteToWideChar(CP_UTF8, 0, filename, -1, wFileName, len);
+  res = (picopal_File)_wfopen(wFileName, m);
+  free(wFileName);
+#else
+  char *m;
+  switch (mode) {
+  case PICOPAL_TEXT_READ:
+    m = "r";
+    break;
+  case PICOPAL_TEXT_WRITE:
+    m = "w";
+    break;
+  case PICOPAL_BINARY_READ:
+    m = "rb";
+    break;
+  case PICOPAL_BINARY_WRITE:
+    m = "wb";
+    break;
+  default:
+    return (picopal_File)NULL;
+  }
+  res = (picopal_File)fopen((char *)filename, m);
+#endif
+  return res;
 }
 
 


### PR DESCRIPTION
This PR introduces support for installing `libpico.dll` in a non-ASCII path on Windows.